### PR TITLE
Fix for aux configuration not being persistent on reconnections

### DIFF
--- a/home/pi/configureAux.sh
+++ b/home/pi/configureAux.sh
@@ -66,7 +66,7 @@ do
 	ID=$(echo "$line" | cut -f 1)
 	NAME=$(echo "$line" | cut -f 2)
 
-	SNK_OPTIONS[INDX]=$ID
+	SNK_OPTIONS[INDX]=$NAME
 	INDX+=1
 	# Remove alsa_output prefix
 	SNK_OPTIONS[INDX]=${NAME/alsa_output./""}


### PR DESCRIPTION
When using the device ID, the selection is not persistent after removing the vita from the dock and reconnecting it. (i.e. audio works on initial setup but reconnecting the vita produces no sound.) This is because the device ID of the usb audio input adapter changes between reconnections. Changing this to use the device name instead fixed this issue in my setup. I was using the audio out from the official Vita 1000 dock from Sony, and the Sonos stereo line-in aux to usb-c adapter, with a usb-c to usb-a adapter on my rpi 4 when the issue occured. (This is my first github commit, sorry if I did any of it wrong).